### PR TITLE
Transition-property skal kun treffe bredde

### DIFF
--- a/src/components/sidebar/SideBar.module.css
+++ b/src/components/sidebar/SideBar.module.css
@@ -9,7 +9,7 @@
   overflow: hidden;
   overflow-y: auto;
   background-color: var(--a-surface-inverted);
-  transition-property: all;
+  transition-property: width, min-width;
   transition-duration: 0.5s;
   transition-timing-function: ease-in-out;
 }


### PR DESCRIPTION
Dette for å unngå en rar forsinkelse på visning av sidebar når man skalerer vinduet i høyden