### PR TITLE
fix(TOB-4275): use https to discover services in fss

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -126,7 +126,7 @@ spec:
 
     # sokos-utbetaling-api
     - name: SOKOS_UTBETALING_API
-      value: http://sokos-utbetaling-api.dev-fss-pub.nais.io
+      value: https://sokos-utbetaling-api.dev-fss-pub.nais.io
     - name: SOKOS_UTBETALING_API_AUDIENCE
       value: api://dev-fss.okonomi.sokos-utbetaling-api/.default
     - name: SOKOS_UTBETALING_API_PROXY

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -118,7 +118,7 @@ spec:
 
     # sokos-utbetaling-api
     - name: SOKOS_UTBETALING_API
-      value: http://sokos-utbetaling-api.prod-fss-pub.nais.io
+      value: https://sokos-utbetaling-api.prod-fss-pub.nais.io
     - name: SOKOS_UTBETALING_API_AUDIENCE
       value: api://prod-fss.okonomi.sokos-utbetaling-api/.default
     - name: SOKOS_UTBETALING_API_PROXY


### PR DESCRIPTION
fix(TOB-4275): use https to discover services in fss
- I forgot to put back the `s` 🥹 