### PR TITLE
refactor: sentraliser og gjenbruk adgangskontroll logikk og microfrontend rendering

### DIFF
--- a/dokumentasjon/mikrofrontend.md
+++ b/dokumentasjon/mikrofrontend.md
@@ -108,44 +108,13 @@
 
 4. Nå skal du legge inn følgende kode:
 
-  ```js
-    ---
-    import { getMicrofrontendConfig } from "src/microfrontend";
-    import { hasAccessToAdGroup } from "src/utils/common";
-    import {
-      fetchMicrofrontendAdGroup,
-      fetchMicrofrontendBundleUrl,
-    } from "src/utils/server/common";
-    import Microfrontend from "../../components/microfrontend/Microfrontend";
-    import Layout from "../../layouts/Layout.astro";
-    import NoAccess from "../NoAccess.astro";
+    ```js
+      ---
+      import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
+      ---
 
-    const attestasjonConfig = getMicrofrontendConfig("attestasjon");
-
-    const hasAccess = hasAccessToAdGroup(
-      Astro.locals.userInfo.adGroups,
-      fetchMicrofrontendAdGroup({
-        adGroupDevelopment: attestasjonConfig.adGroupDevelopment,
-        adGroupProduction: attestasjonConfig.adGroupProduction,
-      })
-    );
-    ---
-
-    <Layout title={attestasjonConfig.title}>
-      <div>
-        {
-          hasAccess ? (
-            <Microfrontend
-              url={fetchMicrofrontendBundleUrl(attestasjonConfig.naisAppName)}
-              client:only="react"
-            />
-          ) : (
-            <NoAccess />
-          )
-        }
-      </div>
-    </Layout>
-  ```
+      <MicrofrontendWrapper appName="attestasjon" />
+    ```
 
 Har du en routing i mikrofrontend? Følg pkt. 1. </br>
 Har du ikke routing i mikrofrontend? Følg pkt. 2 </br>

--- a/src/components/appswitcher/AppSwitcher.tsx
+++ b/src/components/appswitcher/AppSwitcher.tsx
@@ -1,7 +1,10 @@
+import { Heading, Switch } from "@navikt/ds-react";
 import { useState } from "react";
 import { microfrontendConfigArray as allApps } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
-import { Heading, Switch } from "@navikt/ds-react";
+import {
+  getAuthorizedApps,
+  hasAccessToApp,
+} from "src/utils/accessControlUtils";
 import AppCard from "./AppCard";
 import styles from "./AppSwitcher.module.css";
 
@@ -10,12 +13,7 @@ type AppSwitcherProps = {
 };
 
 export default function AppSwitcher(props: AppSwitcherProps) {
-  const authorizedApps = allApps.filter(
-    (app) =>
-      hasAccessToAdGroup(props.adGroups, app.adGroupDevelopment) ||
-      hasAccessToAdGroup(props.adGroups, app.adGroupProduction),
-  );
-
+  const authorizedApps = getAuthorizedApps(props.adGroups);
   const [showApps, setShowApps] = useState<string>("");
 
   function appCards() {
@@ -25,7 +23,7 @@ export default function AppSwitcher(props: AppSwitcherProps) {
       .map((app) => (
         <AppCard
           key={app.app}
-          hasAccess={authorizedApps.includes(app)}
+          hasAccess={hasAccessToApp(props.adGroups, app)}
           route={app.route}
           title={app.title}
           description={app.description}

--- a/src/components/appswitcher/AppSwitcher.tsx
+++ b/src/components/appswitcher/AppSwitcher.tsx
@@ -1,10 +1,7 @@
 import { Heading, Switch } from "@navikt/ds-react";
 import { useState } from "react";
 import { microfrontendConfigArray as allApps } from "src/microfrontend";
-import {
-  getAuthorizedApps,
-  hasAccessToApp,
-} from "src/utils/accessControlUtils";
+import { getAuthorizedApps, hasAccessToApp } from "src/utils/accessControl";
 import AppCard from "./AppCard";
 import styles from "./AppSwitcher.module.css";
 

--- a/src/components/header/AppSwitcherHeader.tsx
+++ b/src/components/header/AppSwitcherHeader.tsx
@@ -1,17 +1,12 @@
-import { hasAccessToAdGroup } from "src/utils/common.ts";
+import { getAuthorizedApps } from "src/utils/accessControlUtils";
 import { MenuGridIcon } from "@navikt/aksel-icons";
 import { Dropdown, InternalHeader } from "@navikt/ds-react";
-import { microfrontendConfigArray as allApps } from "../../microfrontend.ts";
 
 type AppSwitcherHeaderProps = {
   adGroups: string[];
 };
 export default function AppSwitcherHeader(props: AppSwitcherHeaderProps) {
-  const authorizedApps = allApps.filter(
-    (app) =>
-      hasAccessToAdGroup(props.adGroups, app.adGroupDevelopment) ||
-      hasAccessToAdGroup(props.adGroups, app.adGroupProduction),
-  );
+  const authorizedApps = getAuthorizedApps(props.adGroups);
 
   function appSwitcherList() {
     return authorizedApps

--- a/src/components/header/AppSwitcherHeader.tsx
+++ b/src/components/header/AppSwitcherHeader.tsx
@@ -1,6 +1,6 @@
-import { getAuthorizedApps } from "src/utils/accessControlUtils";
 import { MenuGridIcon } from "@navikt/aksel-icons";
 import { Dropdown, InternalHeader } from "@navikt/ds-react";
+import { getAuthorizedApps } from "src/utils/accessControl";
 
 type AppSwitcherHeaderProps = {
   adGroups: string[];

--- a/src/components/microfrontend/MicrofrontendWrapper.astro
+++ b/src/components/microfrontend/MicrofrontendWrapper.astro
@@ -1,0 +1,31 @@
+---
+import { getMicrofrontendConfig } from "src/microfrontend";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
+import { fetchMicrofrontendBundleUrl } from "src/utils/server/common";
+import Microfrontend from "./Microfrontend";
+import Layout from "../../layouts/Layout.astro";
+import NoAccess from "../../pages/NoAccess.astro";
+
+interface Props {
+  appName: string;
+}
+
+const { appName } = Astro.props;
+const appConfig = getMicrofrontendConfig(appName);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+---
+
+<Layout title={appConfig.title}>
+  <div>
+    {
+      hasAccess ? (
+        <Microfrontend
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
+          client:only="react"
+        />
+      ) : (
+        <NoAccess />
+      )
+    }
+  </div>
+</Layout>

--- a/src/components/microfrontend/MicrofrontendWrapper.astro
+++ b/src/components/microfrontend/MicrofrontendWrapper.astro
@@ -1,10 +1,10 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import { fetchMicrofrontendBundleUrl } from "src/utils/server/common";
-import Microfrontend from "./Microfrontend";
+import { hasAccessToApp } from "src/utils/accessControl";
+import { fetchMicrofrontendBundleUrl } from "src/utils/server/fetchBundle";
 import Layout from "../../layouts/Layout.astro";
 import NoAccess from "../../pages/NoAccess.astro";
+import Microfrontend from "./Microfrontend";
 
 interface Props {
   appName: string;

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -2,7 +2,7 @@ import { HouseIcon, MenuHamburgerIcon, XMarkIcon } from "@navikt/aksel-icons";
 import { Button, Link } from "@navikt/ds-react";
 import type { PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
-import { getAuthorizedApps } from "src/utils/accessControlUtils";
+import { getAuthorizedApps } from "src/utils/accessControl";
 import styles from "./SideBar.module.css";
 
 type SideBarProps = {

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -1,9 +1,8 @@
-import type { PropsWithChildren } from "react";
-import { useEffect, useState } from "react";
-import { microfrontendConfigArray as allApps } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
 import { HouseIcon, MenuHamburgerIcon, XMarkIcon } from "@navikt/aksel-icons";
 import { Button, Link } from "@navikt/ds-react";
+import type { PropsWithChildren } from "react";
+import { useEffect, useState } from "react";
+import { getAuthorizedApps } from "src/utils/accessControlUtils";
 import styles from "./SideBar.module.css";
 
 type SideBarProps = {
@@ -11,6 +10,7 @@ type SideBarProps = {
 };
 
 export default function SideBar({ adGroups }: SideBarProps) {
+  const authorizedApps = getAuthorizedApps(adGroups);
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
@@ -19,12 +19,6 @@ export default function SideBar({ adGroups }: SideBarProps) {
     });
     document.dispatchEvent(event);
   }, [isOpen]);
-
-  const authorizedApps = allApps.filter(
-    (app) =>
-      hasAccessToAdGroup(adGroups, app.adGroupDevelopment) ||
-      hasAccessToAdGroup(adGroups, app.adGroupProduction),
-  );
 
   const handleToggle = () => {
     setIsOpen(!isOpen);

--- a/src/microfrontend.ts
+++ b/src/microfrontend.ts
@@ -1,4 +1,4 @@
-type MicroFrontend = {
+export type MicroFrontend = {
   app: string;
   title: string;
   description: string;

--- a/src/pages/attestasjon/[...attestasjon].astro
+++ b/src/pages/attestasjon/[...attestasjon].astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../../components/microfrontend/Microfrontend";
 import Layout from "../../layouts/Layout.astro";
 import NoAccess from "../NoAccess.astro";
 
-const attestasjonConfig = getMicrofrontendConfig("attestasjon");
+const appConfig = getMicrofrontendConfig("attestasjon");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: attestasjonConfig.adGroupDevelopment,
-    adGroupProduction: attestasjonConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={attestasjonConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(attestasjonConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/attestasjon/[...attestasjon].astro
+++ b/src/pages/attestasjon/[...attestasjon].astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../../components/microfrontend/Microfrontend";
-import Layout from "../../layouts/Layout.astro";
-import NoAccess from "../NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("attestasjon");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="attestasjon" />

--- a/src/pages/buntkontroll.astro
+++ b/src/pages/buntkontroll.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const buntkontrollConfig = getMicrofrontendConfig("buntkontroll");
+const appConfig = getMicrofrontendConfig("buntkontroll");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: buntkontrollConfig.adGroupDevelopment,
-    adGroupProduction: buntkontrollConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={buntkontrollConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(buntkontrollConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/buntkontroll.astro
+++ b/src/pages/buntkontroll.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("buntkontroll");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="buntkontroll" />

--- a/src/pages/fastedata/[...fastedata].astro
+++ b/src/pages/fastedata/[...fastedata].astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToApp } from 'src/utils/accessControlUtils';
-import {
-fetchMicrofrontendBundleUrl
-} from 'src/utils/server/common';
-import Microfrontend from '../../components/microfrontend/Microfrontend';
-import Layout from '../../layouts/Layout.astro';
-import NoAccess from '../NoAccess.astro';
-
-const appConfig = getMicrofrontendConfig('fastedata');
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="fastedata" />

--- a/src/pages/fastedata/[...fastedata].astro
+++ b/src/pages/fastedata/[...fastedata].astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToAdGroup } from 'src/utils/common';
+import { hasAccessToApp } from 'src/utils/accessControlUtils';
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from 'src/utils/server/common';
 import Microfrontend from '../../components/microfrontend/Microfrontend';
 import Layout from '../../layouts/Layout.astro';
 import NoAccess from '../NoAccess.astro';
 
-const fastedataConfig = getMicrofrontendConfig('fastedata');
+const appConfig = getMicrofrontendConfig('fastedata');
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: fastedataConfig.adGroupDevelopment,
-    adGroupProduction: fastedataConfig.adGroupProduction,
-  }),
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={fastedataConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(fastedataConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/grensesnittmal.astro
+++ b/src/pages/grensesnittmal.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToAdGroup } from 'src/utils/common';
+import { hasAccessToApp } from 'src/utils/accessControlUtils';
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from 'src/utils/server/common';
 import Microfrontend from '../components/microfrontend/Microfrontend';
 import Layout from '../layouts/Layout.astro';
 import NoAccess from './NoAccess.astro';
 
-const grensesnittmalConfig = getMicrofrontendConfig('grensesnittmal');
+const appConfig = getMicrofrontendConfig('grensesnittmal');
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: grensesnittmalConfig.adGroupDevelopment,
-    adGroupProduction: grensesnittmalConfig.adGroupProduction,
-  }),
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={grensesnittmalConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(grensesnittmalConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/grensesnittmal.astro
+++ b/src/pages/grensesnittmal.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToApp } from 'src/utils/accessControlUtils';
-import {
-fetchMicrofrontendBundleUrl
-} from 'src/utils/server/common';
-import Microfrontend from '../components/microfrontend/Microfrontend';
-import Layout from '../layouts/Layout.astro';
-import NoAccess from './NoAccess.astro';
-
-const appConfig = getMicrofrontendConfig('grensesnittmal');
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="grensesnittmal" />

--- a/src/pages/kontoregister-organisasjon.astro
+++ b/src/pages/kontoregister-organisasjon.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("kro");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="kro" />

--- a/src/pages/kontoregister-organisasjon.astro
+++ b/src/pages/kontoregister-organisasjon.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const kroConfig = getMicrofrontendConfig("kro");
+const appConfig = getMicrofrontendConfig("kro");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: kroConfig.adGroupDevelopment,
-    adGroupProduction: kroConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={kroConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(kroConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/kontoregister-person.astro
+++ b/src/pages/kontoregister-person.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("krp");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="krp" />

--- a/src/pages/kontoregister-person.astro
+++ b/src/pages/kontoregister-person.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const krpConfig = getMicrofrontendConfig("krp");
+const appConfig = getMicrofrontendConfig("krp");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: krpConfig.adGroupDevelopment,
-    adGroupProduction: krpConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={krpConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(krpConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/meldingsflyt.astro
+++ b/src/pages/meldingsflyt.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const meldingsflytConfig = getMicrofrontendConfig("meldingsflyt");
+const appConfig = getMicrofrontendConfig("meldingsflyt");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: meldingsflytConfig.adGroupDevelopment,
-    adGroupProduction: meldingsflytConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={meldingsflytConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(meldingsflytConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/meldingsflyt.astro
+++ b/src/pages/meldingsflyt.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("meldingsflyt");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="meldingsflyt" />

--- a/src/pages/oppdragsinfo/[...oppdragsinfo].astro
+++ b/src/pages/oppdragsinfo/[...oppdragsinfo].astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../../components/microfrontend/Microfrontend";
 import Layout from "../../layouts/Layout.astro";
 import NoAccess from "../NoAccess.astro";
 
-const oppdragsinfoConfig = getMicrofrontendConfig("oppdragsinfo");
+const appConfig = getMicrofrontendConfig("oppdragsinfo");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: oppdragsinfoConfig.adGroupDevelopment,
-    adGroupProduction: oppdragsinfoConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={oppdragsinfoConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(oppdragsinfoConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/oppdragsinfo/[...oppdragsinfo].astro
+++ b/src/pages/oppdragsinfo/[...oppdragsinfo].astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../../components/microfrontend/Microfrontend";
-import Layout from "../../layouts/Layout.astro";
-import NoAccess from "../NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("oppdragsinfo");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="oppdragsinfo" />

--- a/src/pages/oppslag-reskontro-stoenad.astro
+++ b/src/pages/oppslag-reskontro-stoenad.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const orsConfig = getMicrofrontendConfig("ors");
+const appConfig = getMicrofrontendConfig("ors");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: orsConfig.adGroupDevelopment,
-    adGroupProduction: orsConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={orsConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(orsConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/oppslag-reskontro-stoenad.astro
+++ b/src/pages/oppslag-reskontro-stoenad.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("ors");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="ors" />

--- a/src/pages/resending-bank.astro
+++ b/src/pages/resending-bank.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const resendingbankConfig = getMicrofrontendConfig("resending-bank");
+const appConfig = getMicrofrontendConfig("resending-bank");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: resendingbankConfig.adGroupDevelopment,
-    adGroupProduction: resendingbankConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={resendingbankConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(resendingbankConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/resending-bank.astro
+++ b/src/pages/resending-bank.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("resending-bank");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="resending-bank" />

--- a/src/pages/skattekort.astro
+++ b/src/pages/skattekort.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const skattekortConfig = getMicrofrontendConfig("skattekort");
+const appConfig = getMicrofrontendConfig("skattekort");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: skattekortConfig.adGroupDevelopment,
-    adGroupProduction: skattekortConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={skattekortConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(skattekortConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/skattekort.astro
+++ b/src/pages/skattekort.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("skattekort");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="skattekort" />

--- a/src/pages/spk-mottak.astro
+++ b/src/pages/spk-mottak.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const spkMottakConfig = getMicrofrontendConfig("spk_mottak");
+const appConfig = getMicrofrontendConfig("spk_mottak");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: spkMottakConfig.adGroupDevelopment,
-    adGroupProduction: spkMottakConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={spkMottakConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(spkMottakConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/spk-mottak.astro
+++ b/src/pages/spk-mottak.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("spk_mottak");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="spk_mottak" />

--- a/src/pages/utbetaling.astro
+++ b/src/pages/utbetaling.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToApp } from "src/utils/accessControlUtils";
-import {
-fetchMicrofrontendBundleUrl
-} from "src/utils/server/common";
-import Microfrontend from "../components/microfrontend/Microfrontend";
-import Layout from "../layouts/Layout.astro";
-import NoAccess from "./NoAccess.astro";
-
-const appConfig = getMicrofrontendConfig("utbetaling");
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="utbetaling" />

--- a/src/pages/utbetaling.astro
+++ b/src/pages/utbetaling.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from "src/microfrontend";
-import { hasAccessToAdGroup } from "src/utils/common";
+import { hasAccessToApp } from "src/utils/accessControlUtils";
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from "src/utils/server/common";
 import Microfrontend from "../components/microfrontend/Microfrontend";
 import Layout from "../layouts/Layout.astro";
 import NoAccess from "./NoAccess.astro";
 
-const utbetalingConfig = getMicrofrontendConfig("utbetaling");
+const appConfig = getMicrofrontendConfig("utbetaling");
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: utbetalingConfig.adGroupDevelopment,
-    adGroupProduction: utbetalingConfig.adGroupProduction,
-  })
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={utbetalingConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(utbetalingConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/pages/venteregister.astro
+++ b/src/pages/venteregister.astro
@@ -1,29 +1,5 @@
 ---
-import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToApp } from 'src/utils/accessControlUtils';
-import {
-fetchMicrofrontendBundleUrl
-} from 'src/utils/server/common';
-import Microfrontend from '../components/microfrontend/Microfrontend';
-import Layout from '../layouts/Layout.astro';
-import NoAccess from './NoAccess.astro';
-
-const appConfig = getMicrofrontendConfig('venteregister');
-
-const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
+import MicrofrontendWrapper from "../components/microfrontend/MicrofrontendWrapper.astro";
 ---
 
-<Layout title={appConfig.title}>
-  <div>
-    {
-      hasAccess ? (
-        <Microfrontend
-          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
-          client:only="react"
-        />
-      ) : (
-        <NoAccess />
-      )
-    }
-  </div>
-</Layout>
+<MicrofrontendWrapper appName="venteregister" />

--- a/src/pages/venteregister.astro
+++ b/src/pages/venteregister.astro
@@ -1,31 +1,24 @@
 ---
 import { getMicrofrontendConfig } from 'src/microfrontend';
-import { hasAccessToAdGroup } from 'src/utils/common';
+import { hasAccessToApp } from 'src/utils/accessControlUtils';
 import {
-  fetchMicrofrontendAdGroup,
-  fetchMicrofrontendBundleUrl,
+fetchMicrofrontendBundleUrl
 } from 'src/utils/server/common';
 import Microfrontend from '../components/microfrontend/Microfrontend';
 import Layout from '../layouts/Layout.astro';
 import NoAccess from './NoAccess.astro';
 
-const venteregisterConfig = getMicrofrontendConfig('venteregister');
+const appConfig = getMicrofrontendConfig('venteregister');
 
-const hasAccess = hasAccessToAdGroup(
-  Astro.locals.userInfo.adGroups,
-  fetchMicrofrontendAdGroup({
-    adGroupDevelopment: venteregisterConfig.adGroupDevelopment,
-    adGroupProduction: venteregisterConfig.adGroupProduction,
-  }),
-);
+const hasAccess = hasAccessToApp(Astro.locals.userInfo.adGroups, appConfig);
 ---
 
-<Layout title={venteregisterConfig.title}>
+<Layout title={appConfig.title}>
   <div>
     {
       hasAccess ? (
         <Microfrontend
-          url={fetchMicrofrontendBundleUrl(venteregisterConfig.naisAppName)}
+          url={fetchMicrofrontendBundleUrl(appConfig.naisAppName)}
           client:only="react"
         />
       ) : (

--- a/src/utils/accessControl.ts
+++ b/src/utils/accessControl.ts
@@ -1,7 +1,7 @@
 import { microfrontendConfigArray as allApps } from "../microfrontend";
 import type { MicroFrontend } from "../microfrontend";
 
-export function hasAccessToAdGroup(adGroups: string[], uuid: string): boolean {
+function hasAccessToAdGroup(adGroups: string[], uuid: string): boolean {
   return adGroups.includes(uuid);
 }
 

--- a/src/utils/accessControlUtils.ts
+++ b/src/utils/accessControlUtils.ts
@@ -1,0 +1,20 @@
+import { microfrontendConfigArray as allApps } from "../microfrontend";
+import type { MicroFrontend } from "../microfrontend";
+
+export function hasAccessToAdGroup(adGroups: string[], uuid: string): boolean {
+  return adGroups.includes(uuid);
+}
+
+export function getAuthorizedApps(adGroups: string[]): MicroFrontend[] {
+  return allApps.filter((app) => hasAccessToApp(adGroups, app));
+}
+
+export function hasAccessToApp(
+  adGroups: string[],
+  app: MicroFrontend,
+): boolean {
+  return (
+    hasAccessToAdGroup(adGroups, app.adGroupDevelopment) ||
+    hasAccessToAdGroup(adGroups, app.adGroupProduction)
+  );
+}

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,3 +1,0 @@
-export function hasAccessToAdGroup(adGroups: string[], uuid: string): boolean {
-  return adGroups.includes(uuid);
-}

--- a/src/utils/server/fetchBundle.ts
+++ b/src/utils/server/fetchBundle.ts
@@ -1,10 +1,5 @@
 import { getServerSideEnvironment } from "./environment";
 
-type AdGroup = {
-  adGroupDevelopment: string;
-  adGroupProduction: string;
-};
-
 export function fetchMicrofrontendBundleUrl(appName: string) {
   if (getServerSideEnvironment() === "local") {
     return "http://localhost:3000/bundle.js";
@@ -16,13 +11,4 @@ export function fetchMicrofrontendBundleUrl(appName: string) {
     appName +
     "/bundle.js"
   );
-}
-
-export function fetchMicrofrontendAdGroup({
-  adGroupDevelopment,
-  adGroupProduction,
-}: AdGroup) {
-  return getServerSideEnvironment() === "production"
-    ? adGroupProduction
-    : adGroupDevelopment;
 }


### PR DESCRIPTION
- Definerer adgangskontroll sjekk ett sted og gjenbruker denne
- Lager en wrapper for alle mikrofrontendene for å unngå å repetere samme kode ørten ganger