### PR TITLE
TOB-6234: Flytt arbeidsflate Oppgjørsrapporter til eget Nais-namespace

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -153,6 +153,6 @@ spec:
 
     # sokos-up-oppgjorsrapporter (Frontend)
     - name: SOKOS_UP_OPPGJORSRAPPORTER_URL
-      value: http://sokos-up-oppgjorsrapporter
+      value: http://sokos-up-oppgjorsrapporter.oppgjorsrapporter
     - name: SOKOS_UP_OPPGJORSRAPPORTER_AUDIENCE
-      value: api://prod-gcp.okonomi.sokos-up-oppgjorsrapporter/.default
+      value: api://prod-gcp.oppgjorsrapporter.sokos-up-oppgjorsrapporter/.default

--- a/.nais/naiserator-q1.yaml
+++ b/.nais/naiserator-q1.yaml
@@ -62,6 +62,7 @@ spec:
         - application: sokos-astro-template
         - application: sokos-up-skattekort-ssr
         - application: sokos-up-oppgjorsrapporter
+          namespace: oppgjorsrapporter
         - application: sokos-skattekort
         - application: logging
           namespace: nais-system
@@ -182,6 +183,6 @@ spec:
 
     # sokos-up-oppgjorsrapporter (Frontend)
     - name: SOKOS_UP_OPPGJORSRAPPORTER_URL
-      value: http://sokos-up-oppgjorsrapporter
+      value: http://sokos-up-oppgjorsrapporter.oppgjorsrapporter
     - name: SOKOS_UP_OPPGJORSRAPPORTER_AUDIENCE
-      value: api://dev-gcp.okonomi.sokos-up-oppgjorsrapporter/.default
+      value: api://dev-gcp.oppgjorsrapporter.sokos-up-oppgjorsrapporter/.default

--- a/src/pages/oppgjorsrapporter.astro
+++ b/src/pages/oppgjorsrapporter.astro
@@ -9,7 +9,7 @@ const appUrl = isLocalEnv
   ? "http://localhost:4322/"
   : process.env.SOKOS_UP_OPPGJORSRAPPORTER_URL;
 const appAudience = isLocalEnv
-  ? "api://dev-gcp.okonomi.sokos-up-oppgjorsrapporter/.default"
+  ? "api://dev-gcp.oppgjorsrapporter.sokos-up-oppgjorsrapporter/.default"
   : process.env.SOKOS_UP_OPPGJORSRAPPORTER_AUDIENCE;
 ---
 


### PR DESCRIPTION
Selve sokos-up-oppgjorsrapporter er ikke deployet i nytt namespace ennå; dette er bare forberedelser.  Derfor fint om man venter med å merge dette til vi er klare.

Er også litt spent på om det er noen antakelser i utbetalingsportalen som bryter med at mikrofrontends kan bo i andre namespaces; tror dette er første mikrofrontend som forsøkes flyttes ut av `okonomi`?