### PR TITLE
typescript 6: fjern deprekert baseUrl option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,18 @@
 {
 	"extends": "astro/tsconfigs/strict",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
 		"verbatimModuleSyntax": false,
 		"types": ["astro/client"],
 		"paths": {
-			"@components/*": ["src/components/*"],
-			"@layouts/*": ["src/layouts/*"],
-			"@pages/*": ["src/pages/*"],
-			"@types/*": ["src/types/*"],
-			"@schema/*": ["src/types/schema/*"],
-			"@utils/*": ["src/utils/*"],
-			"@config/*": ["src/config/*"]
+			"@components/*": ["./src/components/*"],
+			"@layouts/*": ["./src/layouts/*"],
+			"@pages/*": ["./src/pages/*"],
+			"@types/*": ["./src/types/*"],
+			"@schema/*": ["./src/types/schema/*"],
+			"@utils/*": ["./src/utils/*"],
+			"@config/*": ["./src/config/*"]
 		}
 	},
 	"include": ["src/**/*"],


### PR DESCRIPTION
Ref

https://github.com/microsoft/TypeScript/issues/62508#issuecomment-3348649259